### PR TITLE
Removed torchgeo datasets from workflow

### DIFF
--- a/bda/datasets.py
+++ b/bda/datasets.py
@@ -1,24 +1,105 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""Custom torchgeo datasets."""
-
+"""Custom datasets."""
 import os
-from typing import Callable, Optional
+from typing import List, Callable, Optional
 
-from torchgeo.datasets import RasterDataset
+import torch
+import numpy as np
+from torch.utils.data import Dataset
+import rasterio
 
 
-class SingleRasterDataset(RasterDataset):
-    """A torchgeo dataset that loads a single raster file."""
+def _list_dict_to_dict_list(samples):
+    """Convert a list of dictionaries to a dictionary of lists.
 
-    def __init__(self, fn: str, transforms: Optional[Callable] = None):
-        """Initialize the SingleRasterDataset class.
+    Args:
+        samples: a list of dictionaries
 
-        Args:
-            fn (str): The path to the raster file.
-            transforms (Optional[Callable], optional): The transforms to apply to the
-                raster file. Defaults to None.
-        """
-        self.filename_regex = os.path.basename(fn)
-        super().__init__(paths=os.path.dirname(fn), transforms=transforms)
+    Returns:
+        a dictionary of lists
+    """
+    collated = dict()
+    for sample in samples:
+        for key, value in sample.items():
+            if key not in collated:
+                collated[key] = []
+            collated[key].append(value)
+    return collated
+
+
+def stack_samples(samples):
+    """Stack a list of samples along a new axis.
+
+    Useful for forming a mini-batch of samples to pass to
+    :class:`torch.utils.data.DataLoader`.
+
+    Args:
+        samples: list of samples
+
+    Returns:
+        a single sample
+    """
+    collated = _list_dict_to_dict_list(samples)
+    for key, value in collated.items():
+        if isinstance(value[0], torch.Tensor):
+            collated[key] = torch.stack(value)
+    return collated
+
+
+class TileDataset(Dataset):
+    def __init__(self, image_fns: List[str], mask_fns: List[str], transforms=None, sanity_check=True):
+        self.image_fns = image_fns
+        self.mask_fns = mask_fns
+        if self.mask_fns is not None:
+            assert len(image_fns) == len(mask_fns)
+
+        # Check to make sure that all the image and mask tile pairs are the same size
+        # as a sanity check
+        if sanity_check and mask_fns is not None:
+            print("Running sanity check on dataset...")
+            for image_fn, mask_fn in list(zip(image_fns, mask_fns)):
+                with rasterio.open(image_fn[0]) as f:
+                    image_height, image_width = f.shape
+                with rasterio.open(mask_fn) as f:
+                    mask_height, mask_width = f.shape
+                assert image_height == mask_height
+                assert image_width == mask_width
+
+        self.transforms = transforms
+
+    def __len__(self):
+        return len(self.image_fns)
+
+    def __getitem__(self, index):
+        i, y, x, patch_size = index
+
+        sample = {
+            "y": y,
+            "x": x,
+        }
+
+        window = rasterio.windows.Window(x, y, patch_size, patch_size)
+
+        # Load imagery
+        stack = []
+        for j in range(len(self.image_fns[i])):
+            image_fn = self.image_fns[i][j]
+            with rasterio.open(image_fn) as f:
+                image = f.read(window=window)
+            stack.append(image)
+        stack = np.concatenate(stack, axis=0)
+        sample["image"] = torch.from_numpy(stack).float()
+
+        # Load mask
+        if self.mask_fns is not None:
+            mask_fn = self.mask_fns[i]
+            with rasterio.open(mask_fn) as f:
+                mask = f.read(window=window)
+            sample["mask"] = torch.from_numpy(mask).long()
+
+        if self.transforms is not None:
+            sample = self.transforms(sample)
+
+        return sample

--- a/bda/preprocess.py
+++ b/bda/preprocess.py
@@ -43,4 +43,8 @@ class Preprocessor(object):
             del sample["bbox"]
         if self.training_mode and "bounds" in sample:  # for torchgeo >= 0.6
             del sample["bounds"]
+
+        if not self.training_mode and "bbox" in sample:  # for torchgeo >= 0.6
+            sample["bounds"] = sample["bbox"]
+
         return sample

--- a/bda/samplers.py
+++ b/bda/samplers.py
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import numpy as np
+import rasterio
+from torch.utils.data import Sampler
+
+
+class RandomGeoSampler(Sampler):
+    def __init__(self, image_fns, length, patch_size, tile_size=None, weights=None):
+        self.tile_sample_weights = []
+        self.tile_heights = []
+        self.tile_widths = []
+        self.length = length
+        self.patch_size = patch_size
+
+        if tile_size is None:
+            for image_fn in image_fns:
+                with rasterio.open(image_fn[0]) as f:
+                    image_height, image_width = f.shape
+                self.tile_sample_weights.append(image_height * image_width)
+                self.tile_heights.append(image_height)
+                self.tile_widths.append(image_width)
+        else:
+            for image_fn in image_fns:
+                self.tile_sample_weights.append(tile_size[0] * tile_size[1])
+                self.tile_heights.append(tile_size[0])
+                self.tile_widths.append(tile_size[1])
+
+        if weights is not None:
+            assert len(weights) == len(image_fns)
+            self.tile_sample_weights = weights
+
+        self.tile_sample_weights = np.array(self.tile_sample_weights)
+        self.tile_sample_weights = (
+            self.tile_sample_weights / self.tile_sample_weights.sum()
+        )
+        self.num_tiles = len(self.tile_sample_weights)
+
+    def __iter__(self):
+        for _ in range(len(self)):
+            i = np.random.choice(self.num_tiles, p=self.tile_sample_weights)
+
+            max_y_size = max(self.tile_heights[i] - self.patch_size, 1)
+            max_x_size = max(self.tile_widths[i] - self.patch_size, 1)
+
+            y = np.random.randint(0, max_y_size)
+            x = np.random.randint(0, max_x_size)
+
+            yield (i, y, x, self.patch_size)
+
+    def __len__(self):
+        return self.length
+
+
+class GridGeoSampler(Sampler):
+    def __init__(
+        self,
+        image_fns,
+        image_fn_indices,
+        patch_size=256,
+        stride=256,
+    ):
+        self.image_fn_indices = image_fn_indices
+        self.patch_size = patch_size
+
+        # tuples of the form (i, y, x, patch_size) that index into a CustomTileDataset
+        self.indices = []
+        for i in self.image_fn_indices:
+            with rasterio.open(image_fns[i][0]) as f:
+                height, width = f.height, f.width
+
+            if patch_size > height and patch_size > width:
+                self.indices.append((i, 0, 0, self.patch_size))
+            else:
+                for y in list(range(0, height - patch_size, stride)) + [
+                    height - patch_size
+                ]:
+                    for x in list(range(0, width - patch_size, stride)) + [
+                        width - patch_size
+                    ]:
+                        self.indices.append((i, y, x, self.patch_size))
+        self.num_chips = len(self.indices)
+
+    def __iter__(self):
+        for index in self.indices:
+            yield index
+
+    def __len__(self):
+        return self.num_chips

--- a/bda/trainers.py
+++ b/bda/trainers.py
@@ -3,12 +3,26 @@
 
 """Custom torchgeo trainers."""
 
+from typing import Any
+from torch import Tensor
 from lightning.pytorch.callbacks import Callback
 from torchgeo.trainers import SemanticSegmentationTask
+import kornia.augmentation as K
 
 
 class CustomSemanticSegmentationTask(SemanticSegmentationTask):
     """A custom trainer for semantic segmentation tasks."""
+
+    def __init__(self, *args, **kwargs):
+        del kwargs["ignore"]  # workaround for https://github.com/microsoft/torchgeo/pull/2314, can be removed with torchgeo 0.7
+        super().__init__(*args, **kwargs)
+
+        self.train_augs = K.AugmentationSequential(
+            K.RandomRotation(p=0.5, degrees=90),
+            K.RandomHorizontalFlip(p=0.5),
+            K.RandomVerticalFlip(p=0.5),
+            data_keys=None, keepdim=True
+        )
 
     def configure_callbacks(self) -> list[Callback]:
         """Configures the callbacks for the trainer.
@@ -17,3 +31,27 @@ class CustomSemanticSegmentationTask(SemanticSegmentationTask):
             an empty list to override the default callbacks, we set these in the Trainer
         """
         return []
+
+    def training_step(
+        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Compute the training loss and additional metrics.
+
+        Args:
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
+
+        Returns:
+            The loss tensor.
+        """
+        batch = self.train_augs(batch)
+        x = batch['image']
+        y = batch['mask']
+        batch_size = x.shape[0]
+        y_hat = self(x)
+        loss: Tensor = self.criterion(y_hat, y)
+        self.log('train_loss', loss, batch_size=batch_size)
+        self.train_metrics(y_hat, y)
+        self.log_dict(self.train_metrics, batch_size=batch_size)
+        return loss

--- a/bda/trainers.py
+++ b/bda/trainers.py
@@ -14,7 +14,8 @@ class CustomSemanticSegmentationTask(SemanticSegmentationTask):
     """A custom trainer for semantic segmentation tasks."""
 
     def __init__(self, *args, **kwargs):
-        del kwargs["ignore"]  # workaround for https://github.com/microsoft/torchgeo/pull/2314, can be removed with torchgeo 0.7
+        if "ignore" in kwargs:
+            del kwargs["ignore"]  # workaround for https://github.com/microsoft/torchgeo/pull/2314, can be removed with torchgeo 0.7
         super().__init__(*args, **kwargs)
 
         self.train_augs = K.AugmentationSequential(

--- a/environment.yml
+++ b/environment.yml
@@ -12,13 +12,13 @@ dependencies:
     - deltalake
     - geopandas
     - jupyter
-    - mercantile>=1.2
+    - mercantile
     - osmnx
     - pigeon-jupyter
     - planetary_computer
     - pyarrow
-    - rasterio<1.4  # recent rasterio is incompatible with torchgeo
+    - rasterio
     - s3fs
     - scikit-learn
     - tensorboard
-    - torchgeo[all]<0.6
+    - torchgeo[all]

--- a/inference.py
+++ b/inference.py
@@ -134,16 +134,14 @@ def main() -> None:
         y_coords = batch["y"]
         batch_size = images.shape[0]
         with torch.inference_mode():
-            print("Batch inference started")
             predictions = task(images)
-            print("Batch inference finished")
             predictions = predictions.argmax(axis=1).cpu().numpy().astype(np.uint8)
 
         for i in range(batch_size):
             height, width = predictions[i].shape
             y = int(y_coords[i])
             x = int(x_coords[i])
-            output[y:y+height, x:x+width] = predictions[i]
+            output[y+padding:y+height-padding, x+padding:x+width-padding] = predictions[i][padding:-padding, padding:-padding]
 
     print(f"Finished running model in {time.time()-tic:0.2f} seconds")
 


### PR DESCRIPTION
torchgeo's RasterDatasets don't handle rectangular raster pixels (i.e. rasters in which xres!=yres) -- as a temporary workaround this PR implements all datasets and sampling logic in pure python