### PR TITLE
Add DINOv3 + UPerNet segmentation model (usable in inference.py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# DINOv3+UPerNet training runs (checkpoints, logs, metrics)
+outputs/

--- a/DINOV3_UPERNET.md
+++ b/DINOV3_UPERNET.md
@@ -1,0 +1,89 @@
+# DINOv3 + UPerNet segmentation model
+
+This repo can train and run a [DINOv3](https://ai.meta.com/dinov3/) ViT backbone
+with a [UPerNet](https://arxiv.org/abs/1807.10221) decode head as a drop-in
+alternative to the `segmentation_models_pytorch` U-Net / DeepLabV3+ models. It is
+wired into `CustomSemanticSegmentationTask`, so a trained checkpoint runs through
+`inference.py` unchanged.
+
+## Architecture
+
+`bda/dinov3_upernet.py` implements `DINOv3UPerNet`:
+
+* **Backbone** — a pretrained DINOv3 ViT (loaded from the gated `facebook/dinov3-*`
+  Hugging Face repos). Four equally spaced transformer blocks are read out; the
+  class + register tokens are dropped and the patch tokens are reshaped back to
+  feature maps.
+* **Neck** — the four same-resolution (stride-16) maps are turned into a
+  `{stride 4, 8, 16, 32}` pyramid with transposed-conv / identity / max-pool
+  branches (the BEiT/MAE ViT-UPerNet recipe).
+* **Head** — a UPerNet head (Pyramid Pooling Module + FPN fusion, GroupNorm) that
+  produces per-pixel logits, upsampled to the input resolution.
+
+It maps a `(B, in_channels, H, W)` ImageNet-normalized tensor to `(B, num_classes,
+H, W)` logits, exactly like the other segmentation models.
+
+Available backbones (`backbone=...`): `dinov3_vits16` (21 M), `dinov3_vitb16`,
+`dinov3_vitl16`, `dinov3_vitl16_sat` (satellite-pretrained SAT-493M).
+
+## Requirements
+
+The DINOv3 backbone needs the optional `transformers` dependency (already added to
+`environment.yml`) and access to the **gated** DINOv3 weights:
+
+```bash
+pip install "transformers>=4.56"
+huggingface-cli login          # after requesting access on the model page
+```
+
+`H` and `W` must be divisible by the patch size (16), e.g. a power-of-two
+`inference.patch_size` such as 512.
+
+## Using it in `inference.py`
+
+No code changes are needed — the architecture is rebuilt from the checkpoint's
+hyperparameters. Point the standard inference config at an `upernet` checkpoint:
+
+```bash
+python inference.py --config configs/my_config.yml \
+    --inference.checkpoint_fn checkpoints/last.ckpt \
+    --imagery.raw_fn path/to/image.tif
+```
+
+## Training through `fine_tune.py`
+
+`fine_tune.py` now reads `training.model`, `training.backbone`, and
+`training.weights` from the config (defaulting to the previous
+`unet` / `resnext50_32x4d`). To fine-tune DINOv3 + UPerNet, add:
+
+```yaml
+training:
+  model: upernet
+  backbone: dinov3_vits16
+  weights: true        # load the pretrained DINOv3 backbone
+  # ...existing training keys...
+```
+
+## Example: xView2 (xBD) damage segmentation
+
+`scripts/train_eval_xview2_dinov3_upernet.py` trains and evaluates the model on
+the [xView2 / xBD](https://xview2.org) dataset, collapsing the four damage grades
+into a single `damaged` class in one of three ways
+(`{0: background, 1: undamaged, 2: damaged}`):
+
+| grouping | undamaged | damaged |
+| --- | --- | --- |
+| `any` | no-damage | minor + major + destroyed |
+| `major` | no-damage + minor | major + destroyed |
+| `destroyed` | no-damage + minor + major | destroyed |
+
+```bash
+python scripts/train_eval_xview2_dinov3_upernet.py \
+    --xview2-root ~/data/XView2 --grouping any --gpu 0 \
+    --output-dir outputs/xview2_dinov3_upernet_any
+```
+
+It trains on the `train/` folder (post-disaster RGB, 512-px crops, class-weighted
+cross-entropy for the heavy background imbalance) and reports pixel IoU /
+precision / recall / F1 per class on the **full** `test/` folder. Results are in
+[`RESULTS.md`](scripts/xview2_dinov3_upernet_RESULTS.md).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ A tutorial that walks through how to perform a damage assessment step-by-step wi
 A tutorial that walks through how to perform a damage assessment using a damage proxy map can be found [here](DPM_WORKFLOW.md).
 
 
+## DINOv3 + UPerNet segmentation model
+
+In addition to the `segmentation_models_pytorch` U-Net / DeepLabV3+ models, the
+trainer supports a DINOv3 ViT backbone with a UPerNet decode head (`model:
+upernet`). Trained checkpoints run through `inference.py` unchanged. See
+[DINOV3_UPERNET.md](DINOV3_UPERNET.md) for details and an xView2 (xBD) damage
+segmentation example.
+
+
 ## Results
 
 The Microsoft AI for Good Lab has used this workflow to help our partners respond to a number of disasters. Including:

--- a/bda/dinov3_upernet.py
+++ b/bda/dinov3_upernet.py
@@ -1,0 +1,245 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""DINOv3 + UPerNet semantic-segmentation model.
+
+A plain ViT (DINOv3) backbone paired with a UPerNet (PPM + FPN) decode head, in
+the style of the BEiT / MAE segmentation recipe: four equally spaced transformer
+blocks are read out, reshaped from token sequences back to feature maps, and
+turned into a 4-level ``{stride 4, 8, 16, 32}`` pyramid by a small neck of
+(de)convolutions before the UPerNet head fuses them into per-pixel logits.
+
+The backbone weights come from the gated ``facebook/dinov3-*`` Hugging Face hub
+repos (request access + ``huggingface-cli login`` once). ``transformers`` is an
+optional dependency of this repo -- it is only imported when a ``upernet`` model
+is requested, so the rest of the toolkit works without it.
+
+The module exposes a single ``nn.Module`` (:class:`DINOv3UPerNet`) that maps a
+``(B, in_channels, H, W)`` ImageNet-normalized tensor to ``(B, num_classes, H,
+W)`` logits, so it is a drop-in replacement for the ``segmentation_models_pytorch``
+models used elsewhere in :class:`bda.trainers.CustomSemanticSegmentationTask`.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# Short backbone name -> gated Hugging Face hub id.
+DINOV3_HF_IDS = {
+    "dinov3_vits16": "facebook/dinov3-vits16-pretrain-lvd1689m",
+    "dinov3_vitb16": "facebook/dinov3-vitb16-pretrain-lvd1689m",
+    "dinov3_vitl16": "facebook/dinov3-vitl16-pretrain-lvd1689m",
+    "dinov3_vitl16_sat": "facebook/dinov3-vitl16-pretrain-sat493m",
+}
+
+
+def _norm(num_channels: int) -> nn.GroupNorm:
+    """Batch-size-independent normalization (robust to 1x1 PPM maps / small batches)."""
+    num_groups = 32
+    while num_channels % num_groups:
+        num_groups //= 2
+    return nn.GroupNorm(num_groups, num_channels)
+
+
+def _conv_bn_relu(in_ch: int, out_ch: int, kernel_size: int = 3) -> nn.Sequential:
+    padding = kernel_size // 2
+    return nn.Sequential(
+        nn.Conv2d(in_ch, out_ch, kernel_size, padding=padding, bias=False),
+        _norm(out_ch),
+        nn.ReLU(inplace=True),
+    )
+
+
+class DINOv3Backbone(nn.Module):
+    """DINOv3 ViT that returns four intermediate token maps as feature maps.
+
+    The Hugging Face ``DINOv3ViTModel`` prepends ``1`` class token and
+    ``num_register_tokens`` register tokens to the ``(H/p)*(W/p)`` patch tokens;
+    those prefix tokens are stripped before each selected layer's tokens are
+    reshaped to ``(B, C, H/p, W/p)``.
+    """
+
+    def __init__(
+        self,
+        name: str = "dinov3_vits16",
+        pretrained: bool = True,
+        out_indices: list[int] | None = None,
+    ) -> None:
+        super().__init__()
+        try:
+            from transformers import AutoConfig, AutoModel
+        except ImportError as e:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "The 'upernet' model needs the optional 'transformers' package. "
+                "Install it (see environment.yml) and request access to the gated "
+                f"'{DINOV3_HF_IDS.get(name, name)}' Hugging Face repo."
+            ) from e
+
+        if name not in DINOV3_HF_IDS:
+            raise ValueError(
+                f"Unknown DINOv3 backbone '{name}'. "
+                f"Choose one of {sorted(DINOV3_HF_IDS)}."
+            )
+        hf_id = DINOV3_HF_IDS[name]
+        config = AutoConfig.from_pretrained(hf_id)
+        if pretrained:
+            self.vit = AutoModel.from_pretrained(hf_id)
+        else:
+            self.vit = AutoModel.from_config(config)
+
+        self.patch_size = int(config.patch_size)
+        self.embed_dim = int(config.hidden_size)
+        self.num_prefix_tokens = 1 + int(getattr(config, "num_register_tokens", 0))
+
+        n_layers = int(config.num_hidden_layers)
+        if out_indices is None:
+            # Four equally spaced blocks; hidden_states[0] is the embedding output
+            # and hidden_states[i] is the output of block i, so valid ids are 1..n.
+            out_indices = [n_layers // 4, n_layers // 2, (3 * n_layers) // 4, n_layers]
+        self.out_indices = out_indices
+
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+        b, _, h, w = x.shape
+        if h % self.patch_size or w % self.patch_size:
+            raise ValueError(
+                f"Input {h}x{w} must be divisible by the patch size "
+                f"{self.patch_size}."
+            )
+        gh, gw = h // self.patch_size, w // self.patch_size
+        outputs = self.vit(pixel_values=x, output_hidden_states=True)
+        hidden_states = outputs.hidden_states
+        feats = []
+        for idx in self.out_indices:
+            tokens = hidden_states[idx][:, self.num_prefix_tokens :, :]
+            feat = tokens.transpose(1, 2).reshape(b, self.embed_dim, gh, gw)
+            feats.append(feat.contiguous())
+        return feats
+
+
+class _PPM(nn.ModuleList):
+    """Pyramid Pooling Module (the PSPNet context module used by UPerNet)."""
+
+    def __init__(self, pool_scales, in_dim: int, channels: int) -> None:
+        super().__init__()
+        for scale in pool_scales:
+            self.append(
+                nn.Sequential(
+                    nn.AdaptiveAvgPool2d(scale),
+                    nn.Conv2d(in_dim, channels, 1, bias=False),
+                    _norm(channels),
+                    nn.ReLU(inplace=True),
+                )
+            )
+
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+        out = []
+        for block in self:
+            y = block(x)
+            out.append(
+                F.interpolate(y, size=x.shape[2:], mode="bilinear", align_corners=False)
+            )
+        return out
+
+
+class UPerHead(nn.Module):
+    """UPerNet decode head: PPM on the coarsest level + an FPN fuse of all levels."""
+
+    def __init__(
+        self,
+        in_channels: list[int],
+        channels: int = 256,
+        num_classes: int = 3,
+        pool_scales=(1, 2, 3, 6),
+    ) -> None:
+        super().__init__()
+        # PPM over the last (coarsest) feature map.
+        self.ppm = _PPM(pool_scales, in_channels[-1], channels)
+        self.ppm_bottleneck = _conv_bn_relu(
+            in_channels[-1] + len(pool_scales) * channels, channels, 3
+        )
+        # FPN lateral + output convs for every level except the last.
+        self.lateral_convs = nn.ModuleList(
+            [_conv_bn_relu(c, channels, 1) for c in in_channels[:-1]]
+        )
+        self.fpn_convs = nn.ModuleList(
+            [_conv_bn_relu(channels, channels, 3) for _ in in_channels[:-1]]
+        )
+        self.fpn_bottleneck = _conv_bn_relu(len(in_channels) * channels, channels, 3)
+        self.dropout = nn.Dropout2d(0.1)
+        self.classifier = nn.Conv2d(channels, num_classes, 1)
+
+    def forward(self, feats: list[torch.Tensor]) -> torch.Tensor:
+        laterals = [conv(feats[i]) for i, conv in enumerate(self.lateral_convs)]
+        psp = torch.cat([feats[-1], *self.ppm(feats[-1])], dim=1)
+        laterals.append(self.ppm_bottleneck(psp))
+
+        # Top-down pathway.
+        for i in range(len(laterals) - 1, 0, -1):
+            laterals[i - 1] = laterals[i - 1] + F.interpolate(
+                laterals[i], size=laterals[i - 1].shape[2:], mode="bilinear",
+                align_corners=False,
+            )
+
+        fpn_outs = [self.fpn_convs[i](laterals[i]) for i in range(len(laterals) - 1)]
+        fpn_outs.append(laterals[-1])
+        for i in range(1, len(fpn_outs)):
+            fpn_outs[i] = F.interpolate(
+                fpn_outs[i], size=fpn_outs[0].shape[2:], mode="bilinear",
+                align_corners=False,
+            )
+        out = self.fpn_bottleneck(torch.cat(fpn_outs, dim=1))
+        return self.classifier(self.dropout(out))
+
+
+class DINOv3UPerNet(nn.Module):
+    """DINOv3 ViT backbone + UPerNet head for dense semantic segmentation.
+
+    Args:
+        backbone: DINOv3 short name (see :data:`DINOV3_HF_IDS`).
+        in_channels: number of input channels; a 1x1 stem maps to the 3 channels
+            the pretrained patch embedding expects when ``in_channels != 3``.
+        num_classes: number of output classes.
+        pretrained: load the gated Hugging Face pretrained backbone weights.
+        channels: UPerNet fusion width.
+    """
+
+    def __init__(
+        self,
+        backbone: str = "dinov3_vits16",
+        in_channels: int = 3,
+        num_classes: int = 3,
+        pretrained: bool = True,
+        channels: int = 256,
+    ) -> None:
+        super().__init__()
+        self.stem = (
+            nn.Conv2d(in_channels, 3, 1) if in_channels != 3 else nn.Identity()
+        )
+        self.backbone = DINOv3Backbone(backbone, pretrained=pretrained)
+        dim = self.backbone.embed_dim
+        # Turn the four same-resolution (stride-16) ViT maps into a
+        # {stride 4, 8, 16, 32} pyramid, as in BEiT/MAE UPerNet segmentation.
+        self.fpn1 = nn.Sequential(
+            nn.ConvTranspose2d(dim, dim, 2, stride=2),
+            _norm(dim),
+            nn.GELU(),
+            nn.ConvTranspose2d(dim, dim, 2, stride=2),
+        )
+        self.fpn2 = nn.ConvTranspose2d(dim, dim, 2, stride=2)
+        self.fpn3 = nn.Identity()
+        self.fpn4 = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.decode_head = UPerHead(
+            in_channels=[dim, dim, dim, dim],
+            channels=channels,
+            num_classes=num_classes,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h, w = x.shape[-2:]
+        x = self.stem(x)
+        feats = self.backbone(x)
+        feats = [self.fpn1(feats[0]), self.fpn2(feats[1]), self.fpn3(feats[2]), self.fpn4(feats[3])]
+        logits = self.decode_head(feats)
+        return F.interpolate(logits, size=(h, w), mode="bilinear", align_corners=False)

--- a/bda/trainers.py
+++ b/bda/trainers.py
@@ -41,6 +41,30 @@ class CustomSemanticSegmentationTask(SemanticSegmentationTask):
         """
         return []
 
+    def configure_models(self) -> None:
+        """Initialize the model.
+
+        Adds a ``"upernet"`` option (DINOv3 ViT backbone + UPerNet decode head)
+        on top of the ``segmentation_models_pytorch`` models that torchgeo's
+        :class:`~torchgeo.trainers.SemanticSegmentationTask` supports. Because the
+        architecture is rebuilt from the saved hyperparameters, ``upernet``
+        checkpoints load transparently in ``inference.py``.
+        """
+        if self.hparams["model"] == "upernet":
+            from .dinov3_upernet import DINOv3UPerNet
+
+            self.model = DINOv3UPerNet(
+                backbone=self.hparams["backbone"],
+                in_channels=self.hparams["in_channels"],
+                num_classes=self.hparams["num_classes"],
+                pretrained=self.weights is True,
+            )
+            if self.hparams["freeze_backbone"]:
+                for param in self.model.backbone.parameters():
+                    param.requires_grad = False
+        else:
+            super().configure_models()
+
     def configure_losses(self) -> None:
         """Initialize the loss criterion.
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,5 +26,9 @@ dependencies:
     - scikit-learn
     - setuptools<81
     - tensorboard
+    # Optional: only needed for the DINOv3 + UPerNet ('upernet') segmentation
+    # model (bda/dinov3_upernet.py). The DINOv3 backbones are gated on the HF
+    # hub -- request access and run `huggingface-cli login` once.
+    - transformers>=4.56
     - torchgeo[all]
     - torch<2.11

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -87,10 +87,13 @@ def main() -> None:
 
     # we include +1 to account for our 0 "not labeled" class
     num_classes = len(args["labels"]["classes"]) + 1
+    # Model/backbone default to the smp U-Net used previously, but can be set to
+    # `upernet` + a `dinov3_*` backbone (see bda/dinov3_upernet.py) via the config.
+    training_cfg = args["training"]
     task = CustomSemanticSegmentationTask(
-        model="unet",
-        backbone="resnext50_32x4d",
-        weights=True,  # use ImageNet pre-trained weights
+        model=training_cfg.get("model", "unet"),
+        backbone=training_cfg.get("backbone", "resnext50_32x4d"),
+        weights=training_cfg.get("weights", True),  # ImageNet / pretrained weights
         in_channels=args["imagery"]["num_channels"],
         num_classes=num_classes,
         loss="ce",

--- a/scripts/train_eval_xview2_dinov3_upernet.py
+++ b/scripts/train_eval_xview2_dinov3_upernet.py
@@ -1,0 +1,298 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Train + evaluate a DINOv3 + UPerNet damage-segmentation model on xView2 (xBD).
+
+The xView2 ``targets/*_post_disaster_target.png`` masks label every pixel with
+``0`` background, ``1`` no-damage, ``2`` minor-damage, ``3`` major-damage, ``4``
+destroyed. This script collapses the four damage grades into a single
+``damaged`` class in one of three ways (``--grouping``), producing a 3-class
+segmentation problem ``{0: background, 1: undamaged, 2: damaged}``:
+
+* ``any``       damaged = minor + major + destroyed   (undamaged = no-damage)
+* ``major``     damaged = major + destroyed           (undamaged = no-damage + minor)
+* ``destroyed`` damaged = destroyed                   (undamaged = no-damage + minor + major)
+
+It trains the repo's :class:`bda.trainers.CustomSemanticSegmentationTask` with
+``model="upernet"`` (so the checkpoint loads directly in ``inference.py``) on the
+train folder and reports pixel IoU / precision / recall / F1 per class on the
+**full** test folder.
+
+Example::
+
+    python scripts/train_eval_xview2_dinov3_upernet.py \
+        --xview2-root ~/data/XView2 --grouping any --gpu 0 \
+        --output-dir outputs/xview2_dinov3_upernet_any
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import random
+import time
+
+import lightning.pytorch as pl
+import numpy as np
+import torch
+from lightning.pytorch.callbacks import ModelCheckpoint
+from PIL import Image
+from torch.utils.data import DataLoader, Dataset
+
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from bda.trainers import CustomSemanticSegmentationTask  # noqa: E402
+
+# xView2 damage grade -> {0 background, 1 undamaged, 2 damaged} for each grouping.
+GROUPINGS = {
+    "any": [0, 1, 2, 2, 2],
+    "major": [0, 1, 1, 2, 2],
+    "destroyed": [0, 1, 1, 1, 2],
+}
+CLASS_NAMES = ["background", "undamaged", "damaged"]
+NUM_CLASSES = 3
+
+# ImageNet normalization (DINOv3 backbones expect it); imagery is 8-bit RGB.
+IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32) * 255.0
+IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32) * 255.0
+
+
+def _post_images(root: str, split: str) -> list[str]:
+    fns = sorted(glob.glob(os.path.join(root, split, "images", "*_post_disaster.png")))
+    if not fns:
+        raise SystemExit(f"No post-disaster images under {root}/{split}/images/.")
+    return fns
+
+
+def _target_for(image_fn: str) -> str:
+    d = os.path.dirname(os.path.dirname(image_fn))
+    base = os.path.basename(image_fn).replace(".png", "_target.png")
+    return os.path.join(d, "targets", base)
+
+
+class XView2SegDataset(Dataset):
+    """Post-disaster RGB images + remapped damage masks.
+
+    Training samples random ``crop_size`` windows (biased toward building pixels);
+    evaluation returns the full image so the whole test footprint is scored.
+    """
+
+    def __init__(
+        self,
+        image_fns: list[str],
+        grouping: str,
+        crop_size: int | None = 512,
+        crops_per_image: int = 1,
+        train: bool = True,
+        seed: int = 0,
+    ) -> None:
+        self.image_fns = image_fns
+        self.lut = np.array(GROUPINGS[grouping], dtype=np.uint8)
+        self.crop_size = crop_size
+        self.crops_per_image = crops_per_image if train else 1
+        self.train = train
+        self.rng = random.Random(seed)
+
+    def __len__(self) -> int:
+        return len(self.image_fns) * self.crops_per_image
+
+    def _load(self, idx: int):
+        image_fn = self.image_fns[idx % len(self.image_fns)]
+        image = np.asarray(Image.open(image_fn).convert("RGB"), dtype=np.float32)
+        mask = np.asarray(Image.open(_target_for(image_fn)))
+        mask = self.lut[np.clip(mask, 0, 4)].astype(np.int64)
+        return image, mask
+
+    def _random_crop(self, image: np.ndarray, mask: np.ndarray):
+        h, w = mask.shape
+        cs = self.crop_size
+        if h <= cs or w <= cs:
+            return image, mask
+        # Bias 80% of crops toward a window that contains building pixels.
+        best = None
+        for attempt in range(10):
+            y = self.rng.randint(0, h - cs)
+            x = self.rng.randint(0, w - cs)
+            m = mask[y : y + cs, x : x + cs]
+            if attempt == 0 or self.rng.random() > 0.8 or (m > 0).any():
+                return image[y : y + cs, x : x + cs], m
+            best = (image[y : y + cs, x : x + cs], m)
+        return best
+
+    def __getitem__(self, idx: int):
+        image, mask = self._load(idx)
+        if self.train and self.crop_size is not None:
+            image, mask = self._random_crop(image, mask)
+        image = (image - IMAGENET_MEAN) / IMAGENET_STD
+        image = torch.from_numpy(image.transpose(2, 0, 1).copy()).float()
+        mask = torch.from_numpy(mask.copy()).long()
+        return {"image": image, "mask": mask}
+
+
+def compute_class_weights(image_fns: list[str], grouping: str, sample: int = 300):
+    """Inverse-sqrt-frequency class weights (normalized to mean 1) for weighted CE."""
+    lut = np.array(GROUPINGS[grouping], dtype=np.uint8)
+    counts = np.zeros(NUM_CLASSES, dtype=np.float64)
+    rng = random.Random(0)
+    fns = image_fns if len(image_fns) <= sample else rng.sample(image_fns, sample)
+    for fn in fns:
+        m = lut[np.clip(np.asarray(Image.open(_target_for(fn))), 0, 4)]
+        b = np.bincount(m.reshape(-1), minlength=NUM_CLASSES)
+        counts += b[:NUM_CLASSES]
+    freq = counts / counts.sum()
+    w = 1.0 / np.sqrt(freq + 1e-6)
+    w = w / w.mean()
+    return torch.tensor(w, dtype=torch.float32), counts
+
+
+@torch.inference_mode()
+def evaluate(task, image_fns: list[str], grouping: str, device, batch_size: int = 2):
+    """Accumulate a 3x3 confusion matrix over the full images -> per-class metrics."""
+    ds = XView2SegDataset(image_fns, grouping, crop_size=None, train=False)
+    loader = DataLoader(ds, batch_size=batch_size, num_workers=8)
+    model = task.model.eval().to(device)
+    conf = np.zeros((NUM_CLASSES, NUM_CLASSES), dtype=np.int64)
+    for batch in loader:
+        x = batch["image"].to(device)
+        y = batch["mask"].numpy().reshape(-1)
+        pred = model(x).argmax(1).cpu().numpy().reshape(-1)
+        conf += np.bincount(
+            y * NUM_CLASSES + pred, minlength=NUM_CLASSES**2
+        ).reshape(NUM_CLASSES, NUM_CLASSES)
+    metrics = {"confusion_matrix": conf.tolist(), "per_class": {}}
+    ious, f1s = [], []
+    for c in range(NUM_CLASSES):
+        tp = conf[c, c]
+        fp = conf[:, c].sum() - tp
+        fn = conf[c, :].sum() - tp
+        iou = tp / (tp + fp + fn) if (tp + fp + fn) else float("nan")
+        prec = tp / (tp + fp) if (tp + fp) else float("nan")
+        rec = tp / (tp + fn) if (tp + fn) else float("nan")
+        f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else float("nan")
+        metrics["per_class"][CLASS_NAMES[c]] = {
+            "iou": float(iou), "precision": float(prec),
+            "recall": float(rec), "f1": float(f1),
+            "support": int(conf[c, :].sum()),
+        }
+        ious.append(iou)
+        f1s.append(f1)
+    metrics["mean_iou"] = float(np.nanmean(ious))
+    metrics["damaged_f1"] = metrics["per_class"]["damaged"]["f1"]
+    metrics["overall_accuracy"] = float(np.trace(conf) / conf.sum())
+    return metrics
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--xview2-root", default=os.path.expanduser("~/data/XView2"))
+    p.add_argument("--grouping", choices=list(GROUPINGS), required=True)
+    p.add_argument("--backbone", default="dinov3_vits16")
+    p.add_argument("--gpu", type=int, default=0)
+    p.add_argument("--crop-size", type=int, default=512)
+    p.add_argument("--batch-size", type=int, default=16)
+    p.add_argument("--crops-per-image", type=int, default=4)
+    p.add_argument("--max-epochs", type=int, default=30)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--val-fraction", type=float, default=0.1)
+    p.add_argument("--num-workers", type=int, default=12)
+    p.add_argument("--output-dir", required=True)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--limit", type=int, default=None,
+                   help="Cap #images per split (smoke-testing only).")
+    args = p.parse_args()
+
+    pl.seed_everything(args.seed, workers=True)
+    os.makedirs(args.output_dir, exist_ok=True)
+    device = torch.device(f"cuda:{args.gpu}" if torch.cuda.is_available() else "cpu")
+
+    train_fns = _post_images(args.xview2_root, "train")
+    rng = random.Random(args.seed)
+    rng.shuffle(train_fns)
+    n_val = int(len(train_fns) * args.val_fraction)
+    val_fns, tr_fns = train_fns[:n_val], train_fns[n_val:]
+    test_fns = _post_images(args.xview2_root, "test")
+    if args.limit:
+        tr_fns, val_fns, test_fns = (
+            tr_fns[: args.limit], val_fns[: max(2, args.limit // 5)],
+            test_fns[: args.limit],
+        )
+    print(
+        f"grouping={args.grouping}  train={len(tr_fns)} val={len(val_fns)} "
+        f"test={len(test_fns)} images"
+    )
+
+    class_weights, counts = compute_class_weights(tr_fns, args.grouping)
+    print(f"class pixel counts {counts.astype(int)}  weights {class_weights.numpy()}")
+
+    train_ds = XView2SegDataset(
+        tr_fns, args.grouping, crop_size=args.crop_size,
+        crops_per_image=args.crops_per_image, train=True, seed=args.seed,
+    )
+    val_ds = XView2SegDataset(
+        val_fns, args.grouping, crop_size=args.crop_size, train=False,
+    )
+    train_loader = DataLoader(
+        train_ds, batch_size=args.batch_size, shuffle=True,
+        num_workers=args.num_workers, drop_last=True, pin_memory=True,
+    )
+    val_loader = DataLoader(
+        val_ds, batch_size=2, num_workers=args.num_workers,
+    )
+
+    task = CustomSemanticSegmentationTask(
+        model="upernet",
+        backbone=args.backbone,
+        weights=True,  # pretrained DINOv3 backbone
+        in_channels=3,
+        num_classes=NUM_CLASSES,
+        loss="ce",
+        class_weights=class_weights,
+        ignore_index=255,  # nothing ignored; background (0) is a real class
+        lr=args.lr,
+        patience=5,
+    )
+
+    ckpt_dir = os.path.join(args.output_dir, "checkpoints")
+    checkpoint_cb = ModelCheckpoint(
+        monitor="val_loss", dirpath=ckpt_dir, save_top_k=1, save_last=True,
+        filename="best-{epoch:02d}-{val_loss:.4f}",
+    )
+    trainer = pl.Trainer(
+        max_epochs=args.max_epochs,
+        accelerator="gpu",
+        devices=[args.gpu],
+        precision="16-mixed",
+        callbacks=[checkpoint_cb],
+        logger=pl.loggers.CSVLogger(args.output_dir, name="logs"),
+        log_every_n_steps=20,
+    )
+    tic = time.time()
+    trainer.fit(task, train_dataloaders=train_loader, val_dataloaders=val_loader)
+    print(f"trained in {(time.time()-tic)/60:.1f} min; best={checkpoint_cb.best_model_path}")
+
+    best = checkpoint_cb.best_model_path or checkpoint_cb.last_model_path
+    eval_task = CustomSemanticSegmentationTask.load_from_checkpoint(best, map_location="cpu")
+    metrics = evaluate(eval_task, test_fns, args.grouping, device)
+    metrics["grouping"] = args.grouping
+    metrics["backbone"] = args.backbone
+    metrics["checkpoint"] = best
+    metrics["n_test_images"] = len(test_fns)
+    out_json = os.path.join(args.output_dir, "test_metrics.json")
+    with open(out_json, "w") as f:
+        json.dump(metrics, f, indent=2)
+
+    print(f"\n== TEST metrics ({args.grouping}) ==")
+    for c in CLASS_NAMES:
+        m = metrics["per_class"][c]
+        print(f"  {c:11s} IoU={m['iou']:.3f} P={m['precision']:.3f} "
+              f"R={m['recall']:.3f} F1={m['f1']:.3f}")
+    print(f"  mIoU={metrics['mean_iou']:.3f}  damaged_F1={metrics['damaged_f1']:.3f} "
+          f"OA={metrics['overall_accuracy']:.3f}")
+    print(f"wrote {out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/xview2_dinov3_upernet_RESULTS.md
+++ b/scripts/xview2_dinov3_upernet_RESULTS.md
@@ -1,0 +1,50 @@
+# xView2 DINOv3 + UPerNet results
+
+Fully-supervised DINOv3 ViT-S/16 + UPerNet (`scripts/train_eval_xview2_dinov3_upernet.py`),
+trained on the xView2 (xBD) `train/` folder and evaluated on the **full**
+`test/` folder (933 post-disaster images, per-pixel metrics accumulated over a
+3×3 confusion matrix). Each row is a separate model that collapses the four xBD
+damage grades into one `damaged` class differently; every model is a 3-class
+`{background, undamaged, damaged}` segmentation.
+
+**Training config:** backbone `dinov3_vits16` (LVD-1689M, pretrained, fine-tuned
+end-to-end), 512-px random crops (80% biased to contain building pixels),
+batch 16, class-weighted cross-entropy (inverse-sqrt-frequency), AdamW lr 1e-4,
+15 epochs, mixed precision, ImageNet normalization. Best-`val_loss` checkpoint.
+
+## Test-set metrics (per-pixel)
+
+| Grouping (damaged =) | Class | IoU | Precision | Recall | F1 |
+| --- | --- | --- | --- | --- | --- |
+| **any** (minor+major+destroyed) | background | 0.954 | 0.994 | 0.960 | 0.976 |
+| | undamaged | 0.542 | 0.601 | 0.847 | 0.703 |
+| | damaged | 0.354 | 0.391 | 0.791 | 0.523 |
+| **major** (major+destroyed) | background | 0.958 | 0.994 | 0.963 | 0.978 |
+| | undamaged | 0.563 | 0.610 | 0.879 | 0.720 |
+| | damaged | 0.377 | 0.424 | 0.774 | 0.548 |
+| **destroyed** (destroyed only) | background | 0.958 | 0.994 | 0.964 | 0.979 |
+| | undamaged | 0.587 | 0.629 | 0.898 | 0.739 |
+| | damaged | 0.271 | 0.298 | 0.749 | 0.426 |
+
+| Grouping | mean IoU | damaged F1 | overall accuracy |
+| --- | --- | --- | --- |
+| any | 0.617 | 0.523 | 0.952 |
+| major | 0.632 | 0.548 | 0.957 |
+| destroyed | 0.605 | 0.426 | 0.959 |
+
+**Notes.** The damaged class is rare (≈0.3–2% of pixels) and gets rarer from
+`any` → `destroyed`, which is why its IoU drops accordingly. The class-weighted
+loss trades precision for recall (damaged recall 0.75–0.79), i.e. the models find
+most damaged pixels at the cost of some false positives — a reasonable operating
+point for triage. A larger backbone (`dinov3_vitb16` / `dinov3_vitl16_sat`),
+longer training, or post-hoc thresholding would push these further.
+
+Reproduce:
+
+```bash
+for g in any major destroyed; do
+  python scripts/train_eval_xview2_dinov3_upernet.py \
+      --xview2-root ~/data/XView2 --grouping $g --gpu 0 \
+      --output-dir outputs/xview2_dinov3_upernet_$g
+done
+```

--- a/scripts/xview2_split_sizes.csv
+++ b/scripts/xview2_split_sizes.csv
@@ -1,0 +1,12 @@
+disaster,train_patches,train_footprints,val_patches,val_footprints,test_patches,test_footprints,total_patches,total_footprints
+guatemala-volcano,17,759,1,97,5,32,23,888
+hurricane-florence,291,5761,28,685,108,2268,427,8714
+hurricane-harvey,286,20440,33,2574,108,7715,427,30729
+hurricane-matthew,215,11338,23,2601,73,4189,311,18128
+hurricane-michael,304,19967,39,2719,98,5657,441,28343
+mexico-earthquake,113,29788,8,2483,38,11411,159,43682
+midwest-flooding,251,8334,28,422,80,2532,359,11288
+palu-tsunami,102,26643,11,4751,42,12560,155,43954
+santa-rosa-wildfire,204,11977,22,973,74,4226,300,17176
+socal-fire,737,9677,86,798,307,4272,1130,14747
+TOTAL,2520,144684,279,18103,933,54862,3732,217649

--- a/scripts/xview2_split_stats.py
+++ b/scripts/xview2_split_stats.py
@@ -1,0 +1,117 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Summarize the xView2 (xBD) train/val/test split used by the DINOv3+UPerNet
+example (``scripts/train_eval_xview2_dinov3_upernet.py``).
+
+Reproduces the exact split -- the ``train/`` folder is shuffled with ``--seed``
+and the first ``--val-fraction`` becomes ``val`` (the rest ``train``); the
+``test/`` folder is ``test`` -- and writes a CSV of the number of **patches**
+(1024x1024 post-disaster image tiles) and **footprints** (building polygons in
+the post-disaster label JSONs) per disaster per split, plus a TOTAL row.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import json
+import os
+import random
+
+SPLITS = ["train", "val", "test"]
+
+
+def _post_images(root: str, folder: str) -> list[str]:
+    fns = sorted(glob.glob(os.path.join(root, folder, "images", "*_post_disaster.png")))
+    if not fns:
+        raise SystemExit(f"No post-disaster images under {root}/{folder}/images/.")
+    return fns
+
+
+def _disaster(image_fn: str) -> str:
+    # e.g. ".../hurricane-harvey_00000123_post_disaster.png" -> "hurricane-harvey"
+    return os.path.basename(image_fn).split("_")[0]
+
+
+def _num_footprints(image_fn: str) -> int:
+    folder = os.path.dirname(os.path.dirname(image_fn))
+    label_fn = os.path.join(
+        folder, "labels", os.path.basename(image_fn).replace(".png", ".json")
+    )
+    feats = json.load(open(label_fn))["features"]["xy"]
+    return sum(1 for f in feats if f.get("properties", {}).get("feature_type") == "building")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--xview2-root", default=os.path.expanduser("~/data/XView2"))
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--val-fraction", type=float, default=0.1)
+    p.add_argument("--output", default="scripts/xview2_split_sizes.csv")
+    args = p.parse_args()
+
+    train_fns = _post_images(args.xview2_root, "train")
+    random.Random(args.seed).shuffle(train_fns)
+    n_val = int(len(train_fns) * args.val_fraction)
+    split_fns = {
+        "val": train_fns[:n_val],
+        "train": train_fns[n_val:],
+        "test": _post_images(args.xview2_root, "test"),
+    }
+
+    # disaster -> split -> (patches, footprints)
+    patches: dict[str, dict[str, int]] = {}
+    footprints: dict[str, dict[str, int]] = {}
+    for split in SPLITS:
+        for fn in split_fns[split]:
+            d = _disaster(fn)
+            patches.setdefault(d, {s: 0 for s in SPLITS})
+            footprints.setdefault(d, {s: 0 for s in SPLITS})
+            patches[d][split] += 1
+            footprints[d][split] += _num_footprints(fn)
+
+    header = ["disaster"]
+    for s in SPLITS:
+        header += [f"{s}_patches", f"{s}_footprints"]
+    header += ["total_patches", "total_footprints"]
+
+    rows = []
+    totals = {f"{s}_patches": 0 for s in SPLITS}
+    totals.update({f"{s}_footprints": 0 for s in SPLITS})
+    for d in sorted(patches):
+        row = {"disaster": d}
+        tp = tf = 0
+        for s in SPLITS:
+            row[f"{s}_patches"] = patches[d][s]
+            row[f"{s}_footprints"] = footprints[d][s]
+            totals[f"{s}_patches"] += patches[d][s]
+            totals[f"{s}_footprints"] += footprints[d][s]
+            tp += patches[d][s]
+            tf += footprints[d][s]
+        row["total_patches"] = tp
+        row["total_footprints"] = tf
+        rows.append(row)
+
+    total_row = {"disaster": "TOTAL"}
+    total_row.update(totals)
+    total_row["total_patches"] = sum(totals[f"{s}_patches"] for s in SPLITS)
+    total_row["total_footprints"] = sum(totals[f"{s}_footprints"] for s in SPLITS)
+    rows.append(total_row)
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=header)
+        w.writeheader()
+        w.writerows(rows)
+
+    widths = {h: max(len(h), *(len(str(r[h])) for r in rows)) for h in header}
+    print(" | ".join(h.ljust(widths[h]) for h in header))
+    for r in rows:
+        print(" | ".join(str(r[h]).ljust(widths[h]) for h in header))
+    print(f"\nWrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a **DINOv3 ViT backbone + UPerNet decode head** as a segmentation option
(`model: upernet`) alongside the existing `segmentation_models_pytorch` U-Net /
DeepLabV3+ models. Because the architecture is rebuilt from the checkpoint's
saved hyperparameters, **trained `upernet` checkpoints run through `inference.py`
with no changes** — this is the "allow using this model in inference.py" goal.

## What's included

- **`bda/dinov3_upernet.py`** — `DINOv3UPerNet` `nn.Module`. A pretrained DINOv3
  ViT (gated `facebook/dinov3-*` HF weights) is read out at four transformer
  blocks; the class + register tokens are dropped and the patch tokens reshaped
  to feature maps, turned into a `{stride 4, 8, 16, 32}` pyramid (the BEiT/MAE
  ViT-UPerNet neck) and fused by a UPerNet PPM + FPN head (GroupNorm) into
  per-pixel logits. It maps `(B, C, H, W)` → `(B, num_classes, H, W)`, a drop-in
  for the smp models.
- **`bda/trainers.py`** — `CustomSemanticSegmentationTask.configure_models()`
  builds the `upernet` model from its hyperparameters (falls back to
  `super().configure_models()` otherwise), so `load_from_checkpoint` in
  `inference.py` works transparently.
- **`fine_tune.py`** — reads optional `training.model` / `training.backbone` /
  `training.weights` from the config (defaults preserve the previous
  `unet` + `resnext50_32x4d` behaviour), so the new model can be trained through
  the standard flow.
- **`environment.yml`** — adds the optional `transformers` dependency (only
  imported when a `upernet` model is used).
- **`scripts/train_eval_xview2_dinov3_upernet.py`** — a self-contained example
  that trains + evaluates on xView2 (xBD), collapsing the four damage grades into
  one `damaged` class three different ways.
- **`DINOV3_UPERNET.md`** + README pointer, and
  **`scripts/xview2_dinov3_upernet_RESULTS.md`**.

## Backbones

`dinov3_vits16` (21 M), `dinov3_vitb16`, `dinov3_vitl16`, `dinov3_vitl16_sat`
(satellite-pretrained SAT-493M). The DINOv3 weights are gated — request access
and `huggingface-cli login` once.

## xView2 (xBD) example results

DINOv3 ViT-S/16 + UPerNet, trained on the xBD `train/` folder, evaluated on the
**full** `test/` folder (933 images), 3-class `{background, undamaged, damaged}`:

| Grouping (damaged =) | mean IoU | damaged IoU | damaged F1 | overall acc |
| --- | --- | --- | --- | --- |
| any (minor+major+destroyed) | 0.617 | 0.354 | 0.523 | 0.952 |
| major (major+destroyed) | 0.632 | 0.377 | 0.548 | 0.957 |
| destroyed (destroyed only) | 0.605 | 0.271 | 0.426 | 0.959 |

Full per-class IoU / precision / recall / F1 in
[`scripts/xview2_dinov3_upernet_RESULTS.md`](scripts/xview2_dinov3_upernet_RESULTS.md).

## Testing

- Model forward/backward verified at batch size 1 and 4 (GroupNorm → batch-size
  independent); output shape `(B, num_classes, H, W)`.
- End-to-end checkpoint round-trip verified: a `upernet` task saved with
  `Trainer.save_checkpoint` and reloaded via
  `CustomSemanticSegmentationTask.load_from_checkpoint` (exactly what
  `inference.py` does) reproduces identical outputs.
- All three xView2 models trained (15 epochs) and evaluated on the full test set.

## Notes

- Inputs must be divisible by the patch size (16), e.g. a power-of-two
  `inference.patch_size` such as 512 (already required by `inference.py`).
- `transformers` is imported lazily, so the rest of the toolkit is unaffected if
  it is not installed.
