### PR TITLE
Multi-GPU training and generalized constraint loss

### DIFF
--- a/bda/config.py
+++ b/bda/config.py
@@ -4,7 +4,7 @@
 """Methods to handle the parsing and merging of command line and YAML file arguments."""
 
 import argparse
-from typing import Callable, Optional
+from typing import Callable, Optional, Sequence, Union
 
 import yaml
 
@@ -40,6 +40,43 @@ _DEFAULT_CONFIG = {
         "checkpoint_fn": str,
     },
 }
+
+
+def normalize_gpu_ids(
+    gpu_ids: Optional[Union[Sequence[int], str, int]] = None,
+    gpu_id: Optional[int] = None,
+) -> list[int]:
+    """Normalize a GPU specification into an ordered, de-duplicated list of ids.
+
+    Precedence: an explicit ``gpu_ids`` (list/tuple, or a comma/space separated
+    string) takes priority over a single ``gpu_id``. Returns an empty list when
+    neither is provided (i.e. CPU).
+
+    Args:
+        gpu_ids: A list/tuple of ints, a comma/space-separated string (e.g.
+            ``"0,1,2"``), a single int, or ``None``.
+        gpu_id: A single GPU id, used only when ``gpu_ids`` is ``None``.
+
+    Returns:
+        Ordered list of unique GPU ids.
+    """
+    raw: list = []
+    if gpu_ids is not None:
+        if isinstance(gpu_ids, str):
+            raw = gpu_ids.replace(",", " ").split()
+        elif isinstance(gpu_ids, int):
+            raw = [gpu_ids]
+        else:
+            raw = list(gpu_ids)
+    elif gpu_id is not None:
+        raw = [gpu_id]
+
+    ids: list[int] = []
+    for item in raw:
+        value = int(item)
+        if value not in ids:
+            ids.append(value)
+    return ids
 
 
 def _get_base_parser(description: Optional[str]) -> argparse.ArgumentParser:

--- a/bda/trainers.py
+++ b/bda/trainers.py
@@ -13,10 +13,63 @@ import torch.nn as nn
 import segmentation_models_pytorch as smp
 
 
+def constraint_segmentation_loss(
+    y_hat: Tensor,
+    y: Tensor,
+    no_damage_index: int,
+    damaged_class_index: int = 3,
+) -> Tensor:
+    """Constraint loss for weakly-supervised "No Damage" labels.
+
+    Standard cross-entropy is applied to every labeled pixel *except* those of
+    the "No Damage" class. At a "No Damage" pixel we don't know the true class
+    (building vs. background), only that the building is *not* damaged -- so
+    instead of a hard label we add a penalty on the predicted probability of the
+    "Damaged Building" class there.
+
+    Args:
+        y_hat: Predicted logits of shape ``(N, C, H, W)``.
+        y: Integer mask of shape ``(N, H, W)``; 0 is the unlabeled/ignored class.
+        no_damage_index: Mask value of the "No Damage" class. This equals
+            ``labels.classes.index("No Damage") + 1`` and therefore depends on
+            the config (4 without a "Cloud" class, 5 with one), so it must be
+            passed in rather than hardcoded.
+        damaged_class_index: Output channel / mask value of the "Damaged
+            Building" class that is penalized at "No Damage" pixels.
+
+    Returns:
+        The scalar loss.
+    """
+    ce_loss = F.cross_entropy(y_hat, y, ignore_index=0, reduction="none")
+    standard_mask = (y > 0) & (y != no_damage_index)
+    if standard_mask.any():
+        loss = ce_loss[standard_mask].mean()
+    else:
+        # No "standard" labeled pixels in this batch (e.g. a patch that is
+        # entirely "No Damage" + unlabeled). Avoid a NaN from mean() over an
+        # empty tensor while staying attached to the autograd graph.
+        loss = y_hat.sum() * 0.0
+
+    constraint_mask = y == no_damage_index
+    if constraint_mask.any():
+        probs = F.softmax(y_hat, dim=1)
+        penalty = probs[:, damaged_class_index, :, :][constraint_mask]
+        loss = loss + penalty.mean()
+
+    return loss
+
+
 class CustomSemanticSegmentationTask(SemanticSegmentationTask):
     """A custom trainer for semantic segmentation tasks."""
 
-    def __init__(self, *args, use_constraint_loss=False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        use_constraint_loss=False,
+        no_damage_index=None,
+        damaged_class_index=3,
+        **kwargs,
+    ):
         if "ignore" in kwargs:
             del kwargs[
                 "ignore"
@@ -24,6 +77,13 @@ class CustomSemanticSegmentationTask(SemanticSegmentationTask):
         super().__init__(*args, **kwargs)
 
         self.use_constraint_loss = use_constraint_loss
+        # Mask value of the "No Damage" class for the constraint loss. Mask values
+        # are (index in labels.classes) + 1, so this is config-dependent and is
+        # passed in by fine_tune.py rather than hardcoded.
+        self.no_damage_index = no_damage_index
+        # Output channel / mask value of the "Damaged Building" class penalized at
+        # "No Damage" pixels (consistently 3 in this repo's schema).
+        self.damaged_class_index = damaged_class_index
 
         self.train_augs = K.AugmentationSequential(
             K.RandomRotation(p=0.5, degrees=90),
@@ -86,16 +146,14 @@ class CustomSemanticSegmentationTask(SemanticSegmentationTask):
         y_hat = self(x)
 
         if self.use_constraint_loss:
-            ce_loss = F.cross_entropy(y_hat, y, ignore_index=0, reduction="none")
-            standard_mask = (y > 0) & (y != 5)
-            loss = ce_loss[standard_mask].mean()
-
-            constraint_mask = y == 5
-            if constraint_mask.any():
-                probs = F.softmax(y_hat, dim=1)
-                penalty = probs[:, 3, :, :][constraint_mask]
-                constraint_loss = penalty.mean()
-                loss = loss + constraint_loss
+            if self.no_damage_index is None:
+                raise ValueError(
+                    "use_constraint_loss is True but no_damage_index is not set. "
+                    "Pass the mask value of the 'No Damage' class (see fine_tune.py)."
+                )
+            loss = constraint_segmentation_loss(
+                y_hat, y, self.no_damage_index, self.damaged_class_index
+            )
         else:
             loss = self.criterion(y_hat, y)
 

--- a/configs/example_config.yml
+++ b/configs/example_config.yml
@@ -36,6 +36,8 @@ training:
   max_epochs: 40
   batch_size: 32
   gpu_id: 0
+  # gpu_ids: [0, 1, 2, 3]  # Optional: list of GPU ids for multi-GPU (DDP) training.
+                           # When set (with >1 id) it overrides gpu_id.
   log_dir: logs/
   checkpoint_subdir: checkpoints/
   use_constraint_loss: false

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -4,14 +4,14 @@
 """Script for fine-tuning a segmentation model to detect damage in satellite imagery."""
 
 import argparse
+import glob
 import os
 
 import lightning.pytorch as pl
-import torch
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import TensorBoardLogger
 
-from bda.config import get_args
+from bda.config import get_args, normalize_gpu_ids
 from bda.datamodules import SegmentationDataModule
 from bda.trainers import CustomSemanticSegmentationTask
 
@@ -29,6 +29,15 @@ def add_fine_tune_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
         help="Name of the experiment (used for TensorBoard logging)",
     )
     parser.add_argument("--training.gpu_id", type=int, help="GPU id to use")
+    parser.add_argument(
+        "--training.gpu_ids",
+        type=int,
+        nargs="+",
+        help=(
+            "One or more GPU ids for multi-GPU (DDP) training, e.g."
+            " `--training.gpu_ids 0 1 2 3`. Overrides `--training.gpu_id`."
+        ),
+    )
     parser.add_argument("--training.batch_size", type=int, help="Batch size")
     parser.add_argument(
         "--training.learning_rate", type=float, help="Learning rate for optimizer"
@@ -67,7 +76,13 @@ def main() -> None:
     assert os.path.exists(os.path.join(experiment_dir, "masks/"))
 
     checkpoint_dir = os.path.join(experiment_dir, args["training"]["checkpoint_subdir"])
-    if os.path.exists(checkpoint_dir) and not args["overwrite"]:
+    # Check for existing *checkpoints*, not just the directory. Under DDP,
+    # Lightning re-runs this script in a subprocess per GPU; the main process
+    # creates the (empty) checkpoint directory before the workers start, so a
+    # bare directory-existence check would make every worker exit early and the
+    # run would hang.
+    existing_checkpoints = glob.glob(os.path.join(checkpoint_dir, "*.ckpt"))
+    if existing_checkpoints and not args["overwrite"]:
         print(
             "Experiment output files already exist, use --overwrite to overwrite them."
             + " Exiting."
@@ -75,18 +90,54 @@ def main() -> None:
         return
     os.makedirs(checkpoint_dir, exist_ok=True)
 
+    gpu_ids = normalize_gpu_ids(
+        args["training"].get("gpu_ids"), args["training"].get("gpu_id")
+    )
+    world_size = max(1, len(gpu_ids))
+
+    # `train_batches_per_epoch` is per-process under DDP, so divide it by the
+    # number of GPUs. This keeps the total batches seen per epoch (and thus the
+    # epoch wall-clock time) roughly constant as GPUs are added -- i.e. more GPUs
+    # makes each epoch faster instead of just processing proportionally more data.
+    train_batches_per_epoch = max(1, 1024 // world_size)
+
     datamodule = SegmentationDataModule(
         os.path.join(experiment_dir, "images/"),
         os.path.join(experiment_dir, "masks/"),
         batch_size=args["training"]["batch_size"],
-        num_workers=24,
-        train_batches_per_epoch=1024,
+        num_workers=4,
+        train_batches_per_epoch=train_batches_per_epoch,
         means=args["imagery"]["normalization_means"],
         stds=args["imagery"]["normalization_stds"],
     )
 
     # we include +1 to account for our 0 "not labeled" class
-    num_classes = len(args["labels"]["classes"]) + 1
+    classes = args["labels"]["classes"]
+    num_classes = len(classes) + 1
+
+    # The constraint loss penalizes the predicted "Damaged Building" probability
+    # at "No Damage" pixels. Mask values are (index in classes) + 1, so the
+    # "No Damage" value is config-dependent (4 without a "Cloud" class, 5 with
+    # one) and must be derived here rather than hardcoded in the trainer.
+    use_constraint_loss = args["training"]["use_constraint_loss"]
+    no_damage_index = None
+    damaged_class_index = 3
+    if use_constraint_loss:
+        missing = [c for c in ("No Damage", "Damaged Building") if c not in classes]
+        if missing:
+            raise ValueError(
+                "training.use_constraint_loss is true but labels.classes is "
+                f"missing {missing}. The constraint loss penalizes 'Damaged "
+                "Building' probability at 'No Damage' pixels, so both classes "
+                "are required."
+            )
+        no_damage_index = classes.index("No Damage") + 1
+        damaged_class_index = classes.index("Damaged Building") + 1
+        print(
+            f"Constraint loss enabled: penalizing P(Damaged Building="
+            f"{damaged_class_index}) at No Damage (={no_damage_index}) pixels"
+        )
+
     task = CustomSemanticSegmentationTask(
         model="unet",
         backbone="resnext50_32x4d",
@@ -97,7 +148,9 @@ def main() -> None:
         ignore_index=0,  # we use 0 as a "not labeled" class by convention
         lr=args["training"]["learning_rate"],
         patience=10,
-        use_constraint_loss=args["training"]["use_constraint_loss"],
+        use_constraint_loss=use_constraint_loss,
+        no_damage_index=no_damage_index,
+        damaged_class_index=damaged_class_index,
     )
 
     checkpoint_callback = ModelCheckpoint(
@@ -109,13 +162,24 @@ def main() -> None:
         save_dir=args["training"]["log_dir"], name=args["experiment_name"]
     )
 
+    # More than one GPU -> data-parallel training via DDP (Lightning's robust
+    # multi-GPU strategy). `use_distributed_sampler=False` keeps our custom
+    # RandomGeoSampler instead of Lightning injecting a DistributedSampler.
+    strategy = "ddp" if world_size > 1 else "auto"
+    print(
+        f"Training on GPU id(s): {gpu_ids} (strategy={strategy}, "
+        f"{train_batches_per_epoch} train batches/epoch/process)"
+    )
+
     trainer = pl.Trainer(
         callbacks=[checkpoint_callback],
         logger=[tb_logger],
         min_epochs=10,
         max_epochs=args["training"]["max_epochs"],
         accelerator="gpu",
-        devices=[args["training"]["gpu_id"]],
+        devices=gpu_ids if gpu_ids else "auto",
+        strategy=strategy,
+        use_distributed_sampler=False,
     )
 
     trainer.fit(model=task, datamodule=datamodule)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Pytest configuration: make the repository root importable (for `import bda`)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for the GPU config helpers in ``bda.config``."""
+
+from bda.config import normalize_gpu_ids
+
+
+# ---------------------------------------------------------------------------
+# normalize_gpu_ids
+# ---------------------------------------------------------------------------
+def test_normalize_list():
+    assert normalize_gpu_ids([0, 1, 2]) == [0, 1, 2]
+
+
+def test_normalize_single_int():
+    assert normalize_gpu_ids(2) == [2]
+
+
+def test_normalize_single_gpu_id_fallback():
+    assert normalize_gpu_ids(None, 3) == [3]
+
+
+def test_normalize_precedence_gpu_ids_over_gpu_id():
+    assert normalize_gpu_ids([0, 1], 5) == [0, 1]
+
+
+def test_normalize_comma_string():
+    assert normalize_gpu_ids("0,1,2") == [0, 1, 2]
+
+
+def test_normalize_space_string():
+    assert normalize_gpu_ids("0 1 2") == [0, 1, 2]
+
+
+def test_normalize_dedupe_preserves_order():
+    assert normalize_gpu_ids([0, 0, 1, 1, 2]) == [0, 1, 2]
+
+
+def test_normalize_none_is_empty():
+    assert normalize_gpu_ids(None, None) == []

--- a/tests/test_trainers.py
+++ b/tests/test_trainers.py
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for the No Damage constraint loss in ``bda.trainers``."""
+
+import torch
+import torch.nn.functional as F
+
+from bda.trainers import constraint_segmentation_loss
+
+
+def _reference_loss(y_hat, y, no_damage_index, damaged_class_index):
+    """Independent re-implementation used to check the helper."""
+    ce = F.cross_entropy(y_hat, y, ignore_index=0, reduction="none")
+    standard_mask = (y > 0) & (y != no_damage_index)
+    loss = ce[standard_mask].mean()
+    constraint_mask = y == no_damage_index
+    if constraint_mask.any():
+        probs = F.softmax(y_hat, dim=1)
+        loss = loss + probs[:, damaged_class_index, :, :][constraint_mask].mean()
+    return loss
+
+
+def test_constraint_fires_for_4_class_layout():
+    """No Damage == 4 (config without a 'Cloud' class)."""
+    torch.manual_seed(0)
+    # num_classes = 5 -> channels 0..4; mask values 0..4, No Damage = 4
+    y_hat = torch.randn(1, 5, 4, 4)
+    y = torch.tensor([[[0, 1, 2, 3], [1, 2, 3, 4], [4, 4, 1, 2], [3, 2, 1, 4]]])
+
+    got = constraint_segmentation_loss(y_hat, y, no_damage_index=4, damaged_class_index=3)
+    expected = _reference_loss(y_hat, y, 4, 3)
+    assert torch.allclose(got, expected)
+
+
+def test_constraint_fires_for_5_class_layout():
+    """No Damage == 5 (config with a 'Cloud' class)."""
+    torch.manual_seed(1)
+    # num_classes = 6 -> channels 0..5; mask values 0..5, No Damage = 5
+    y_hat = torch.randn(1, 6, 4, 4)
+    y = torch.tensor([[[0, 1, 2, 3], [4, 5, 3, 2], [5, 5, 1, 2], [3, 4, 1, 5]]])
+
+    got = constraint_segmentation_loss(y_hat, y, no_damage_index=5, damaged_class_index=3)
+    expected = _reference_loss(y_hat, y, 5, 3)
+    assert torch.allclose(got, expected)
+
+
+def test_penalty_increases_with_predicted_damage_at_no_damage_pixels():
+    """Higher P(Damaged Building) at No Damage pixels must raise the loss."""
+    # One standard Background pixel (1) and one No Damage pixel (4).
+    y = torch.tensor([[[1, 4]]])  # shape (1, 1, 2)
+
+    low = torch.zeros(1, 5, 1, 2)
+    low[0, 1, 0, 0] = 10.0   # confidently Background at the standard pixel
+    low[0, 1, 0, 1] = 10.0   # low P(Damaged Building) at the No Damage pixel
+
+    high = low.clone()
+    high[0, 1, 0, 1] = 0.0
+    high[0, 3, 0, 1] = 10.0  # high P(Damaged Building) at the No Damage pixel
+
+    loss_low = constraint_segmentation_loss(low, y, no_damage_index=4)
+    loss_high = constraint_segmentation_loss(high, y, no_damage_index=4)
+    assert loss_high > loss_low
+
+
+def test_no_constraint_pixels_equals_plain_ce():
+    """With no No Damage pixels the loss is just CE over labeled pixels."""
+    torch.manual_seed(2)
+    y_hat = torch.randn(1, 5, 3, 3)
+    y = torch.tensor([[[0, 1, 2], [3, 1, 2], [2, 3, 1]]])  # no value 4
+
+    got = constraint_segmentation_loss(y_hat, y, no_damage_index=4)
+    ce = F.cross_entropy(y_hat, y, ignore_index=0, reduction="none")
+    expected = ce[(y > 0) & (y != 4)].mean()
+    assert torch.allclose(got, expected)
+
+
+def test_all_no_damage_patch_is_finite():
+    """A patch that is only No Damage (+unlabeled) must not produce NaN."""
+    torch.manual_seed(4)
+    y_hat = torch.randn(1, 5, 3, 3, requires_grad=True)
+    y = torch.tensor([[[0, 4, 4], [4, 0, 4], [4, 4, 0]]])  # only 0 and 4
+
+    loss = constraint_segmentation_loss(y_hat, y, no_damage_index=4)
+    assert torch.isfinite(loss)
+    # Loss is purely the constraint penalty here and should still backprop.
+    loss.backward()
+    assert y_hat.grad is not None
+
+
+def test_fully_unlabeled_patch_is_finite_zero():
+    """A patch with no labeled pixels at all yields a finite (zero) loss."""
+    y_hat = torch.randn(1, 5, 2, 2)
+    y = torch.zeros(1, 2, 2, dtype=torch.long)  # all unlabeled
+    loss = constraint_segmentation_loss(y_hat, y, no_damage_index=4)
+    assert torch.isfinite(loss)
+    assert loss.item() == 0.0
+


### PR DESCRIPTION
## Summary
Adds multi-GPU **training** and generalizes the "No Damage" constraint loss, plus a small test suite. Opened as a **draft**.

### Training (`fine_tune.py`, `bda/config.py`, `bda/trainers.py`)
- **Multi-GPU DDP training** via `--training.gpu_ids` (Lightning `ddp` strategy, `use_distributed_sampler=False` to keep the custom `RandomGeoSampler`). `train_batches_per_epoch` is scaled by world size so per-epoch wall-clock stays ~constant as GPUs are added.
- **Generalized constraint loss**: extracted into a documented `constraint_segmentation_loss()` helper. `no_damage_index` / `damaged_class_index` are now derived from `labels.classes` instead of hardcoded `5`/`3`, so it is correct whether or not a `Cloud` class is present. Adds class-presence validation and an all-nodata-batch NaN guard.
- **DDP-safe checkpoint check**: looks for existing `*.ckpt` files rather than just the checkpoint directory, so DDP subprocesses don't all early-exit and hang.

### Shared / tests
- `bda.config.normalize_gpu_ids()` helper (list/int/comma-or-space string parsing, dedup, `gpu_ids` > `gpu_id` precedence).
- New tests: `tests/test_config.py`, `tests/test_trainers.py` (+ `conftest.py`) — **14 passing**.
- `configs/example_config.yml` documents the new training `gpu_ids` key.

## Testing
- `pytest tests/test_config.py tests/test_trainers.py` → 14 passed
- `ruff check` → clean

🤖 Generated with GitHub Copilot CLI
