### PR TITLE
fix: prevent statistics IndexError on empty building footprints

### DIFF
--- a/merge_with_building_footprints.py
+++ b/merge_with_building_footprints.py
@@ -171,16 +171,19 @@ def main(args):
         f.writerecords(rows)
 
     print(f"Output written to {args.output_fn}")
-    damage_vals_per_geom = np.array(damage_vals_per_geom)
-    breakpoints = [0, 0.2, 0.4, 0.6, 0.8, 1.0001]
-    for i in range(1, len(breakpoints)):
-        count = np.sum(
-            (damage_vals_per_geom[:, 0] >= breakpoints[i - 1])
-            & (damage_vals_per_geom[:, 0] < breakpoints[i])
-        )
-        print(
-            f"- {count} buildings with damage fraction between {breakpoints[i-1]*100:0.0f}% and {breakpoints[i]*100:0.0f}%"
-        )
+    if len(damage_vals_per_geom) > 0:
+        damage_vals_per_geom = np.array(damage_vals_per_geom)
+        breakpoints = [0, 0.2, 0.4, 0.6, 0.8, 1.0001]
+        for i in range(1, len(breakpoints)):
+            count = np.sum(
+                (damage_vals_per_geom[:, 0] >= breakpoints[i - 1])
+                & (damage_vals_per_geom[:, 0] < breakpoints[i])
+            )
+            print(
+                f"- {count} buildings with damage fraction between {breakpoints[i-1]*100:0.0f}% and {breakpoints[i]*100:0.0f}%"
+            )
+    else:
+        print("No buildings found to report statistics.")
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_footprints.py
+++ b/tests/test_merge_footprints.py
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for the merge_with_building_footprints.py script."""
+
+import os
+import subprocess
+import sys
+import numpy as np
+import pytest
+import fiona
+import rasterio
+import shapely.geometry
+
+def create_predictions_raster(filename):
+    crs = "EPSG:4326"
+    transform = rasterio.transform.from_origin(0, 10, 1, 1)
+    # 3 = damage, 2 = built, 4 = unknown, 0 = nodata
+    data = np.zeros((1, 10, 10), dtype=np.uint8)
+    data[0, 1:4, 1:4] = 3  # damage region (9 pixels)
+    with rasterio.open(
+        filename, "w", driver="GTiff", height=10, width=10, count=1, dtype=np.uint8, crs=crs, transform=transform
+    ) as dst:
+        dst.write(data)
+
+def create_footprints(filename, count):
+    schema = {
+        "geometry": "Polygon",
+        "properties": {
+            "id": "str",
+        }
+    }
+    crs = "EPSG:4326"
+    with fiona.open(filename, "w", driver="GPKG", crs=crs, schema=schema) as dst:
+        for i in range(count):
+            offset = i * 2
+            geom = shapely.geometry.box(1 + offset, 1 + offset, 3 + offset, 3 + offset)
+            dst.write({
+                "geometry": shapely.geometry.mapping(geom),
+                "properties": {"id": f"building_{i}"}
+            })
+
+def run_merge_script(footprints_fn, predictions_fn, output_fn):
+    script_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "merge_with_building_footprints.py"
+    )
+    cmd = [
+        sys.executable,
+        script_path,
+        "--footprints_fn", footprints_fn,
+        "--predictions_fn", predictions_fn,
+        "--output_fn", output_fn
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def test_empty_footprints(tmp_path):
+    """Test empty footprints scenario yields a valid empty output with exit code 0."""
+    predictions_fn = str(tmp_path / "predictions.tif")
+    footprints_fn = str(tmp_path / "empty_footprints.gpkg")
+    output_fn = str(tmp_path / "output.gpkg")
+
+    create_predictions_raster(predictions_fn)
+    create_footprints(footprints_fn, 0)
+
+    res = run_merge_script(footprints_fn, predictions_fn, output_fn)
+    assert res.returncode == 0, f"Stdout: {res.stdout}\nStderr: {res.stderr}"
+
+    assert os.path.exists(output_fn)
+    with fiona.open(output_fn) as src:
+        assert len(src) == 0
+        assert src.crs.to_string() == "EPSG:4326"
+        assert "damage_pct_0m" in src.schema["properties"]
+
+
+def test_one_footprint(tmp_path):
+    """Test single footprint processes correctly and prints statistics."""
+    predictions_fn = str(tmp_path / "predictions.tif")
+    footprints_fn = str(tmp_path / "one_footprint.gpkg")
+    output_fn = str(tmp_path / "output.gpkg")
+
+    create_predictions_raster(predictions_fn)
+    create_footprints(footprints_fn, 1)
+
+    res = run_merge_script(footprints_fn, predictions_fn, output_fn)
+    assert res.returncode == 0, f"Stdout: {res.stdout}\nStderr: {res.stderr}"
+
+    assert "1 buildings with damage fraction" in res.stdout
+    assert os.path.exists(output_fn)
+    with fiona.open(output_fn) as src:
+        assert len(src) == 1
+
+
+def test_multiple_footprints(tmp_path):
+    """Test multiple footprints process correctly and print statistics."""
+    predictions_fn = str(tmp_path / "predictions.tif")
+    footprints_fn = str(tmp_path / "multiple_footprints.gpkg")
+    output_fn = str(tmp_path / "output.gpkg")
+
+    create_predictions_raster(predictions_fn)
+    create_footprints(footprints_fn, 3)
+
+    res = run_merge_script(footprints_fn, predictions_fn, output_fn)
+    assert res.returncode == 0, f"Stdout: {res.stdout}\nStderr: {res.stderr}"
+
+    assert "3 buildings with damage fraction" in res.stdout
+    assert os.path.exists(output_fn)
+    with fiona.open(output_fn) as src:
+        assert len(src) == 3


### PR DESCRIPTION
### Summary

This PR fixes a crash in `merge_with_building_footprints.py` when processing datasets containing zero building footprints.

### Root Cause & Fix

When the input footprint file has no building features, `damage_vals_per_geom` is empty. Converting it to a NumPy array yields a 1D array of shape `(0,)`, causing the slicing `damage_vals_per_geom[:, 0]` to raise an `IndexError`. We wrap this statistics logging block in a check to ensure statistics are only computed if there is at least one feature, otherwise printing a clean warning.

### Verification

- Added `tests/test_merge_footprints.py` covering empty footprints (exits with code 0 and produces valid empty GeoPackage), single footprint, and multiple footprint scenarios.
- Verified that empty tests fail on unmodified code and all tests pass after applying the fix.

*Fixes #23*